### PR TITLE
fix: restore /interview/ GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -3,10 +3,13 @@ name: Deploy static site to GitHub Pages
 on:
   push:
     branches: ["main"]
+    paths-ignore:
+      - 'research/**'
+      - 'interview/**'
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
   pages: write
   id-token: write
 
@@ -69,14 +72,6 @@ jobs:
           mkdir -p interview
           cp -r external/InterviewGuide/dist/* interview/
 
-      - name: Commit generated sub-sites if changed
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add research/ interview/
-          git diff --quiet && git diff --staged --quiet || git commit -m "Auto-update external sites"
-          git push || echo "No changes to push"
-
       - uses: actions/upload-pages-artifact@v3
         with:
           path: .
@@ -88,5 +83,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+        with:
+          enablement: true
       - id: deployment
         uses: actions/deploy-pages@v4

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -2,10 +2,6 @@
 name: Deploy static content to Pages
 
 on:
-  # Runs on pushes targeting the default branch
-  push:
-    branches: ["main"]
-
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 

--- a/tests/interviewguide_external_integration.test.sh
+++ b/tests/interviewguide_external_integration.test.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 WORKFLOW_FILE="$ROOT_DIR/.github/workflows/deploy-pages.yml"
+STATIC_WORKFLOW_FILE="$ROOT_DIR/.github/workflows/static.yml"
 INDEX_FILE="$ROOT_DIR/index.html"
 GITIGNORE_FILE="$ROOT_DIR/.gitignore"
 EXTERNAL_DIR="$ROOT_DIR/external/InterviewGuide"
@@ -11,6 +12,21 @@ grep -q "external/InterviewGuide/package-lock.json" "$WORKFLOW_FILE"
 grep -q "working-directory: external/InterviewGuide" "$WORKFLOW_FILE"
 grep -q "BASE_PATH: /AgentGuide/interview" "$WORKFLOW_FILE"
 grep -q "cp -r external/InterviewGuide/dist/\\* interview/" "$WORKFLOW_FILE"
+grep -q "paths-ignore:" "$WORKFLOW_FILE"
+grep -q "'research/\\*\\*'" "$WORKFLOW_FILE"
+grep -q "'interview/\\*\\*'" "$WORKFLOW_FILE"
+grep -q "uses: actions/configure-pages@v5" "$WORKFLOW_FILE"
+grep -q "enablement: true" "$WORKFLOW_FILE"
+if grep -Eq "git add .*research/.*interview/" "$WORKFLOW_FILE"; then
+  echo "workflow should not auto-commit generated research/interview directories"
+  exit 1
+fi
+
+# avoid dual-pages workflows both auto-triggering on push
+if grep -q "^  push:" "$STATIC_WORKFLOW_FILE"; then
+  echo "static.yml should not auto-trigger on push"
+  exit 1
+fi
 
 grep -q "external/InterviewGuide/dist/" "$GITIGNORE_FILE"
 grep -q "external/InterviewGuide/node_modules/" "$GITIGNORE_FILE"


### PR DESCRIPTION
## Summary
- stop the legacy static Pages workflow from redeploying the repository root on every push
- prevent the main Pages workflow from auto-committing generated `research/` and `interview/` folders
- add regression checks for the external InterviewGuide deployment

## Validation
- `bash tests/interviewguide_external_integration.test.sh`
- verified `https://yiweinanzi.github.io/AgentGuide/interview/` returns 200 after deployment

This supersedes #27 with a minimal branch focused only on the Pages 404 fix.