### PR TITLE
docs: add TakoAPI directory badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # AgentGuide
+
+[![Listed on TakoAPI](https://img.shields.io/badge/Listed%20on-TakoAPI-7c3aed)](https://takoapi.com/agents/adongwanai-agentguide)
+
 [![1764666915027.png](https://free.picui.cn/free/2025/12/02/692eadf2be3ac.png)](https://free.picui.cn/free/2025/12/02/692eadf2be3ac.png)
 
 <div align="center">


### PR DESCRIPTION
Hi! 👋 **AgentGuide** is listed in the [TakoAPI](https://takoapi.com) open agent directory — a free, open catalog that helps people discover AI-agent projects ("one API to discover all agents").

Your listing: https://takoapi.com/agents/adongwanai-agentguide

This PR adds a small badge near the top of the README that links back to that listing, so visitors can find the directory entry. It's entirely optional — if you'd prefer not to include it, just close this PR (no hard feelings, and apologies for the noise).

No tracking and no obligations. Thanks for building AgentGuide! 🙏