### PR TITLE
ci: 接入已有校验脚本，并新增已发布站点的存活探测

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+# 运行仓库内已有的校验脚本（tests/）。
+# 这些脚本在 2026-03 修复 /interview/ 404 时写下，用于锁住当时的修复，
+# 但此前没有任何工作流引用它们。
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  checks:
+    name: Static checks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      # tests/site_static_smoke.test.sh 需要 node --check 校验 assets/site.js
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '22'
+
+      - name: Static site smoke checks
+        run: bash tests/site_static_smoke.test.sh
+
+      - name: InterviewGuide / research integration checks
+        run: bash tests/interviewguide_external_integration.test.sh

--- a/.github/workflows/site-health.yml
+++ b/.github/workflows/site-health.yml
@@ -1,0 +1,81 @@
+name: Site health
+
+# 定期访问已发布站点的关键 URL，确认它们仍然可达。
+#
+# 背景：/AgentGuide/interview/ 曾在 2026-02-26 上线后 404，直到 2026-03-09
+# 才由外部贡献者提 PR #36 修复，暴露窗口约 11 天。仓库内的其它校验都是对
+# 源文件做断言，没有任何东西会去访问真实站点。
+#
+# 说明：
+# - 只检查 HTTP 状态码。页面返回 200 但内容损坏，这里检测不到。
+# - GitHub 的定时任务不保证准时，高峰期会延迟甚至跳过；6 小时是名义间隔。
+# - 定时工作流的失败通知发给最后修改过下方 cron 表达式的用户。
+
+on:
+  schedule:
+    - cron: '0 */6 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  probe:
+    name: Probe published URLs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Probe published site
+        run: |
+          set -uo pipefail
+          BASE="https://adongwanai.github.io/AgentGuide"
+          failed=0
+
+          {
+            echo "### 站点探测结果"
+            echo
+            echo "| 结果 | 状态码 | 路径 | 覆盖 |"
+            echo "|:---:|:---:|:---|:---|"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          probe() {
+            path="$1"; expected="$2"; label="$3"
+            # --retry 只对网络错误和 5xx/408/429 生效，404 不会被重试
+            # curl 在连接失败时自身会输出 000，因此这里不再追加，只兜底空值
+            code="$(curl -sS -I -o /dev/null -w '%{http_code}' \
+                      --retry 2 --retry-delay 5 --max-time 30 \
+                      "$BASE$path" 2>/dev/null)" || true
+            code="${code:-000}"
+            if [ "$code" = "$expected" ]; then
+              printf '  ok    %-4s %-38s %s\n' "$code" "$path" "$label"
+              printf '| ✅ | %s | `%s` | %s |\n' "$code" "$path" "$label" >> "$GITHUB_STEP_SUMMARY"
+            else
+              printf '  FAIL  %-4s %-38s %s   (期望 %s)\n' "$code" "$path" "$label" "$expected"
+              printf '| ❌ | %s（期望 %s） | `%s` | %s |\n' "$code" "$expected" "$path" "$label" >> "$GITHUB_STEP_SUMMARY"
+              failed=1
+            fi
+          }
+
+          echo "探测 $BASE"
+          echo
+
+          # 每个探测点对应 deploy-pages.yml 中一个独立的产物拷贝步骤，
+          # 任一步骤失败时其余步骤仍会成功，所以必须逐个覆盖。
+          probe "/"                                 200 "首页 / Pages 服务本身"
+          probe "/assets/site.js"                   200 "cp -r assets/."
+          probe "/data/resources.json"              200 "cp data/resources.json（首页筛选数据源）"
+          probe "/research/"                        200 "ai-research-ebook 构建与拷贝"
+          probe "/research/docs/intro/01-overview/" 200 "research 的 BASE_PATH 与深层路由"
+          probe "/interview/"                       200 "InterviewGuide 构建与拷贝"
+          probe "/interview/questions/q-1/"         200 "interview 的 BASE_PATH 与深层路由"
+
+          # 反向断言：确认不存在的路径确实返回 404。
+          # 若某天引入了 catch-all 兜底规则导致所有路径都返回 200，
+          # 上面全部探测会集体失去意义，这一条用于兜底自检。
+          probe "/__nonexistent-health-probe__/"    404 "404 仍能正确返回（探测器自检）"
+
+          echo
+          if [ "$failed" -ne 0 ]; then
+            echo "站点探测失败：上面标记 FAIL 的 URL 未返回期望状态码。"
+            exit 1
+          fi
+          echo "全部探测点正常。"

--- a/tests/site_static_smoke.test.sh
+++ b/tests/site_static_smoke.test.sh
@@ -5,11 +5,13 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 node --check "$ROOT_DIR/assets/site.js"
 
-rg -q '<link rel="canonical" href="https://adongwanai.github.io/AgentGuide/">' "$ROOT_DIR/index.html"
-rg -q '<meta property="og:image" content="https://adongwanai.github.io/AgentGuide/assets/agentguide-social.png">' "$ROOT_DIR/index.html"
-rg -q 'application/ld\+json' "$ROOT_DIR/index.html"
-rg -q 'data/resources.json' "$ROOT_DIR/assets/site.js"
-rg -q 'data-github-forks' "$ROOT_DIR/index.html"
+# 使用 grep -qF（固定字符串）而非 rg：ripgrep 未必存在于 CI runner 镜像中，
+# 而这些断言全部是字面量匹配，不需要正则。
+grep -qF '<link rel="canonical" href="https://adongwanai.github.io/AgentGuide/">' "$ROOT_DIR/index.html"
+grep -qF '<meta property="og:image" content="https://adongwanai.github.io/AgentGuide/assets/agentguide-social.png">' "$ROOT_DIR/index.html"
+grep -qF 'application/ld+json' "$ROOT_DIR/index.html"
+grep -qF 'data/resources.json' "$ROOT_DIR/assets/site.js"
+grep -qF 'data-github-forks' "$ROOT_DIR/index.html"
 
 python3 - "$ROOT_DIR/data/resources.json" <<'PY'
 import json
@@ -18,12 +20,14 @@ from pathlib import Path
 
 resources = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
 ids = [item["id"] for item in resources]
-assert len(resources) >= 120
+# 下限用于捕捉「生成器产出为空或严重损坏」，不用于统计内容数量。
+# 原值 120 贴着当时的实际条数（121），删除任意一篇文档都会误报。
+assert len(resources) >= 100, f"resources.json only has {len(resources)} items"
 assert len(ids) == len(set(ids))
 assert all(item["category"] and item["type"] and item["level"] for item in resources)
 assert any(item["id"] == "external-learn-workbuddy" for item in resources)
 PY
 
-rg -q '<loc>https://adongwanai.github.io/AgentGuide/</loc>' "$ROOT_DIR/sitemap.xml"
-rg -q '<loc>https://adongwanai.github.io/AgentGuide/research/</loc>' "$ROOT_DIR/sitemap.xml"
-rg -q '<loc>https://adongwanai.github.io/AgentGuide/interview/questions/q-1/</loc>' "$ROOT_DIR/sitemap.xml"
+grep -qF '<loc>https://adongwanai.github.io/AgentGuide/</loc>' "$ROOT_DIR/sitemap.xml"
+grep -qF '<loc>https://adongwanai.github.io/AgentGuide/research/</loc>' "$ROOT_DIR/sitemap.xml"
+grep -qF '<loc>https://adongwanai.github.io/AgentGuide/interview/questions/q-1/</loc>' "$ROOT_DIR/sitemap.xml"


### PR DESCRIPTION
> Draft，待 review。合并前请先看下面的「局限」和「通知归属」两节。

## 背景

`/AgentGuide/interview/` 子站 2026-02-26 上线，到 2026-03-09 才由外部贡献者提 PR #36（分支 `fix/interview-pages-404-v2`）修复，**暴露窗口约 11 天**。

当时的修复提交 `9daaefe9` 同时新增了 `tests/interviewguide_external_integration.test.sh`，逐条断言了事故成因（`BASE_PATH`、`cp -r ... site-dist/interview/`、`paths-ignore`，以及「肇事的 `static.yml` 不许回来」）。

## 问题

**这两个脚本从未被执行过。**

- `.github/` 下只有 `deploy-pages.yml` 和 `update-resources.yml`，都是部署用途，没有一个是校验
- 全仓库搜 `tests/` 零命中（命中的 6 处都是文档正文里的示例代码）
- 没有 `package.json` / `Makefile` / 任何任务入口
- `CONTRIBUTING.md` 第 100、151 行的 PR checklist 写着「本地测试通过 ✅」，但没有任何地方说明测试在哪、怎么跑

防复发装置装了，没通电。

## 改动

### 新增 `.github/workflows/ci.yml`

push / PR 时运行现有的两个脚本，检查源文件层面的断言：

- `node --check assets/site.js` —— 本站没有构建步骤，语法错一个字符首页筛选就整块失效，且服务器一切正常、浏览器静默失败。这是该文件唯一的自动防线
- canonical / og:image / JSON-LD —— 坏了不报错、不白屏、不 404，只是搜索排名下滑，没有其它发现途径
- `resources.json` 的契约：id 唯一、`category`/`type`/`level` 非空、条数下限
- `deploy-pages.yml` 的关键配置（即上次 404 的成因）

### 新增 `.github/workflows/site-health.yml`

每 6 小时（另支持手动触发）访问已发布站点的 8 个 URL。

探测点按 `deploy-pages.yml` 中**各个互相独立的产物拷贝步骤**选取——任一步骤失败时其余步骤仍会成功，只探首页会漏掉大部分故障形态：

| URL | 覆盖 |
|:---|:---|
| `/` | `index.html` 拷贝 + Pages 服务本身 |
| `/assets/site.js` | `cp -r assets/.` |
| `/data/resources.json` | 单独的 `cp data/resources.json`（首页筛选的数据源，挂了表现为「首页能开但资源列表空白」） |
| `/research/` | ai-research-ebook 构建与拷贝 |
| `/research/docs/intro/01-overview/` | research 的 `BASE_PATH` 与深层路由 |
| `/interview/` | InterviewGuide 构建与拷贝（历史 404 现场） |
| `/interview/questions/q-1/` | interview 的 `BASE_PATH` 与深层路由 |
| `/__nonexistent-health-probe__/` | **反向断言**：确认 404 仍返回 404 |

两个子站各覆盖一个深层路由，是因为上次 404 由 `BASE_PATH` 引起，这类故障的典型表现是**子站首页正常、内页全挂**（或反过来）。

最后一条反向断言用于探测器自检：若将来引入 catch-all 兜底规则导致所有路径都返回 200，上面 7 条会集体失去意义。（`vercel.json` 目前就是 `/(.*)` → `/index.html`，在 Pages 侧未生效，但这类规则确实存在于仓库中。）

实现上用 HEAD 请求，单轮约 2 秒、零流量下载（`sitemap.xml` 有 2.6MB，GET 会很浪费）。失败时在 Actions 摘要里输出表格，逐条列出哪个 URL、返回什么、期望什么。

### 修正脚本自身两处问题

- **`rg` → `grep -qF`**：ripgrep 未必存在于 runner 镜像中，而这些断言全是字面量匹配。注意 `'application/ld\+json'` 在 rg 里是正则转义，若直接换成 grep 的基本正则，`\+` 会被解释成「一个或多个 d」而匹配不到原字符串——所以统一用 `-F` 固定字符串
- **`resources.json` 条数下限 120 → 100**：原值贴着当时实际条数（121），余量仅 1，删除任意一篇文档都会误报。该断言的用途是捕捉「生成器产出为空或严重损坏」，不是统计内容数量

## 验证

均在本地完成。

**校验脚本 —— 五项变异测试全部被拦截，基线通过：**

| 人为制造的故障 | 结果 |
|:---|:---|
| 基线（未改动） | `exit=0` ✅ |
| canonical 改成错误域名 | `exit=1` 拦住 |
| `assets/site.js` 插入语法错误 | `exit=1` 拦住 |
| `resources.json` 制造重复 id | `exit=1` 拦住 |
| JSON-LD 标记缺失（验证 `-F` 改写未破坏该断言） | `exit=1` 拦住 |
| 资源条数腰斩至 60（验证新下限仍能拦住损坏产出） | `exit=1` 拦住 |

**存活探测 —— 对线上实跑，8 个 URL 全部返回期望状态码：**

```
  ok    200  /                                      首页 / Pages 服务本身
  ok    200  /assets/site.js                        cp -r assets/.
  ok    200  /data/resources.json                   cp data/resources.json（首页筛选数据源）
  ok    200  /research/                             ai-research-ebook 构建与拷贝
  ok    200  /research/docs/intro/01-overview/      research 的 BASE_PATH 与深层路由
  ok    200  /interview/                            InterviewGuide 构建与拷贝
  ok    200  /interview/questions/q-1/              interview 的 BASE_PATH 与深层路由
  ok    404  /__nonexistent-health-probe__/         404 仍能正确返回（探测器自检）
```

三条失败路径均正确返回非零退出码：子站 404、反向断言失效（模拟 catch-all）、整站不可达（DNS 失败，显示 `000`）。

## 局限

请在合并前确认这几条是可接受的：

- **`ci.yml` 里对 `deploy-pages.yml` 的断言是文本匹配**，防的是「配置被改回上次出事的样子」，**不等于验证部署真的成功**。若故障换一种成因（例如 Astro 升级后产物路径变化），这些 grep 依然是绿的。构建类失败仍由 `deploy-pages` 自身覆盖
- **存活探测只看 HTTP 状态码**。页面返回 200 但内容为空、渲染损坏、JS 报错，检测不到
- **6 小时是名义间隔**。GitHub 官方明确不保证定时任务准时，高峰期会延迟甚至跳过。这套不能当可用性 SLA 用；若需要分钟级实时告警，UptimeRobot 一类的外部服务更合适（5 分钟粒度、自带邮件/短信、完全不碰仓库，注册配置约五分钟）
- **`/interview/questions/q-1/` 是具体题目 ID**。若题库重编导致该 ID 消失会产生误报。选它而非列表页，是因为深层内容页才是上次那类故障的真实受害者；误报改一行即可，漏报的代价参考这次的 11 天
- **定时工作流在 PR 分支上不会运行**（GitHub 只在默认分支执行 cron），所以合并前无法在 Actions 里看到探测实跑。上面贴的是本地 curl 结果。已加 `workflow_dispatch`，合并后可在 Actions 页面手动触发一次立即验证

## 通知归属

两个工作流的失败通知规则不同：

- **`ci.yml`（push / PR 触发）**：发给该次 push 或开 PR 的人。谁改坏的谁收到，随人自动变化，无需配置
- **`site-health.yml`（定时触发）**：无人触发，GitHub 发给**最后修改过该文件中 cron 表达式的用户**。按当前提交，邮件会进提交者邮箱，本仓库 owner 不会收到

若希望由 owner 接收探测告警，需要 owner 本人编辑一次那行 cron（例如 `0 */6 * * *` → `5 */6 * * *`，网页上直接提交即可），归属随之转移。没有其它开关。

建议先让提交者收一两周，确认误报率可接受后再交接——GitHub 的定时任务会抖动，头几次可能出现假警报，那是调参窗口。

另：两者都受各人自己的 `Settings → Notifications → Actions` 控制，这是个人设置，仓库层面无法代为开启。

## 影响面

不改动任何内容文件、不改动 `deploy-pages.yml` 和 `update-resources.yml`、不影响线上部署。改动为两个新增工作流 + 一个测试脚本的等价改写。

---
_Generated by [Claude Code](https://claude.ai/code/session_01NnGcYe9ZCZPG8WcxD78jpv)_