### PR TITLE
docs: 补充 Paper Agent 蓝图的社区实现

### DIFF
--- a/projects/01-paper-agent/README.md
+++ b/projects/01-paper-agent/README.md
@@ -159,6 +159,15 @@ outputs/paper-agent/<run-id>/
 
 > 构建论文研读 Agent，接入 arXiv、Semantic Scholar 和 PDF 解析工具，使用分层 context builder 管理 query、候选论文、证据片段和生成草稿；为每条综述结论保留 paper/page/section 引用，设计 20 条主题检索和单篇精读 eval case，统计相关性、引用准确率、幻觉率和平均成本。
 
+## 社区实现
+
+- [agent-interview](https://github.com/11XuX/agent-interview)：按本蓝图实现的完整项目，同一业务用三种 Agent 形态各写一遍（写死的 workflow / 裸 ReAct / deepagents harness），附三形态对照跑分数据。
+
+  - 架构与本蓝图一一对应：Planner → Paper Search Tools → Paper Ranker → PDF Reader → Evidence Store → Synthesis Agent → Review Agent
+  - 数据源用 Europe PMC 的 `fullTextXML` 接口，直接返回带 `<sec><title>` 的结构化全文，**免去 PDF 解析**（PyMuPDF / Docling 那一层可以整块跳过）
+  - 21 个 commit 一步一个 LangGraph 概念，可 `git checkout` 逐步走，适合当 LangGraph 入门材料
+  - 实测结论：文献密集的题上写死的 workflow 引用密度是 agent 形态的 2 倍以上；交叉领域的题上 workflow 会撞死循环上限并**静默降级**（交出看似正常实则敷衍的短报告），agent 形态则能自适应但 token 成本随轮次二次增长
+
 ## 参考项目与资料
 
 - [GPT Researcher](https://github.com/assafelovic/gpt-researcher)：开源深度研究 Agent，适合学习 research report pipeline。

--- a/projects/04-end-to-end-projects/README.md
+++ b/projects/04-end-to-end-projects/README.md
@@ -151,6 +151,22 @@
 - RAG 与 tool use 如何结合。
 - 文档/数据库/知识库连接器生态。
 
+### [agent-interview](https://github.com/11XuX/agent-interview)
+
+**定位**：同一个文献综述业务的三种 Agent 形态实现与对照，可当 LangGraph 入门材料。
+
+**适合学习**：
+
+- 同一业务下 workflow / ReAct / agent harness 三种形态的代码规模与成本差异
+- LangGraph 的 Send 扇出、双回边、`interrupt` 与 checkpointer 恢复语义
+- 引用可追溯的设计：证据同时保留 paper_id / section / quote，使"引文是否逐字来自原文"成为可用代码 100% 判定的硬约束
+
+**重点看**：
+
+- 三形态并列的目录结构 —— 同一业务一个要 18 个文件、一个 33 行，不对称本身是结论
+- `nodes/review.py` 的两层校验：能用代码查死的（引用真伪、引文是否为原文子串）不交给模型
+- `docs/eval-design.md` 的评测方法论：先枚举失败模式再倒推指标
+
 ## Web / Computer-Use Agent
 
 ### [BrowserGym](https://github.com/ServiceNow/BrowserGym)


### PR DESCRIPTION
按 projects/01-paper-agent 的蓝图实现的完整项目，同一文献综述业务用三种
Agent 形态各实现一遍（workflow / ReAct / deepagents harness），附对照跑分。

- projects/01-paper-agent/README.md 新增「社区实现」一节
- projects/04-end-to-end-projects/README.md 的 Graph / Workflow 分类新增条目